### PR TITLE
Integrate monitoring stack with Django app

### DIFF
--- a/ansible/files/monitoring/docker-compose.yml
+++ b/ansible/files/monitoring/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     image: grafana/grafana:latest
     container_name: grafana
     env_file:
-      - .env        # Load variables from .env file
+      - .env
     ports:
       - "3000:3000"
     depends_on:
@@ -20,6 +20,13 @@ services:
     restart: always
     volumes:
       - grafana_data:/var/lib/grafana
+
+  node_exporter:
+    image: prom/node-exporter:latest
+    container_name: node_exporter
+    restart: always
+    network_mode: "host"
+    pid: "host"            
 
 volumes:
   grafana_data:

--- a/ansible/files/monitoring/prometheus.yml
+++ b/ansible/files/monitoring/prometheus.yml
@@ -1,7 +1,25 @@
-global:
-  scrape_interval: 15s
-
 scrape_configs:
+  # 1. Prometheus self-monitoring
   - job_name: "prometheus"
     static_configs:
       - targets: ["prometheus:9090"]
+        labels:
+          role: prometheus
+          environment: production
+
+  # 2. Django (Notes App) metrics
+  - job_name: "notes_app"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["52.6.125.207:8000"]
+        labels:
+          app: notes_app
+          environment: production
+
+  # 3. Node Exporter (host metrics: CPU, RAM, Disk)
+  - job_name: "node_exporter"
+    static_configs:
+      - targets: ["52.6.125.207:9100"]
+        labels:
+          role: host
+          environment: production

--- a/mynotes/settings.py
+++ b/mynotes/settings.py
@@ -41,9 +41,12 @@ INSTALLED_APPS = [
     "api.apps.ApiConfig",
     'rest_framework',
     'corsheaders',
+    'django_prometheus',
 ]
 
 MIDDLEWARE = [
+    'django_prometheus.middleware.PrometheusBeforeMiddleware',
+    
     "django.middleware.security.SecurityMiddleware",
     
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -56,6 +59,8 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    
+    'django_prometheus.middleware.PrometheusAfterMiddleware',
 ]
 
 ROOT_URLCONF = "mynotes.urls"

--- a/mynotes/urls.py
+++ b/mynotes/urls.py
@@ -22,6 +22,9 @@ from api.views import FrontendAppView
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("api.urls")),
+    
+        # Prometheus metrics
+    path('metrics/', include('django_prometheus.urls')),
     # Catch-all for React
     re_path(r'^.*$', FrontendAppView.as_view(), name='frontend'),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ pytest-django==4.11.1
 
 whitenoise==6.5.0
 gunicorn==23.0.0
+prometheus_client==0.23.1


### PR DESCRIPTION
- Update Prometheus config to scrape Django metrics and Node Exporter
- Modify monitoring Docker Compose for persistent Grafana storage
- Update Django settings for Prometheus metrics endpoint
- Add monitoring dependencies to requirements.txt
- Update URLs to include metrics endpoint